### PR TITLE
Fix Terraform Plan To Create Docker Repository

### DIFF
--- a/infrastructure/environments/gcp/primus_infrastructure/docker_repository.tf
+++ b/infrastructure/environments/gcp/primus_infrastructure/docker_repository.tf
@@ -3,4 +3,5 @@ resource "google_artifact_registry_repository" "stone" {
   repository_id = "stone"
   description   = "A repository of the Docker Images required to run the services in Primus. Named after Sir Benjamin Stone."
   format        = "DOCKER"
+  project = google_project.pmqs_cloud_foundation.id
 }

--- a/infrastructure/environments/gcp/primus_infrastructure/project.tf
+++ b/infrastructure/environments/gcp/primus_infrastructure/project.tf
@@ -7,9 +7,11 @@ data "google_folder" "primus" {
   lookup_organization = true
 }
 
+data "google_client_config" "this" {}
+
 resource "google_project" "pmqs_cloud_foundation" {
   name                = "Primus Infrastructure"
-  project_id          = "primus-infrastructure"
+  project_id          = data.google_client_config.this.project
   billing_account     = data.google_billing_account.pmqs_cloud_billing_account.id
   auto_create_network = false
   folder_id           = data.google_folder.primus.id


### PR DESCRIPTION
Now that we have Terraform CI in place, we can fix up the resources so that our Docker Repository is created. This also means we should make objects that can refer to the object representation of the project, such that Terraform will not try and create objects within a project without first creating the project itself.