### PR TITLE
Give more expansive permissions for debugging

### DIFF
--- a/infrastructure/environments/gcp/primus_infrastructure/iam.tf
+++ b/infrastructure/environments/gcp/primus_infrastructure/iam.tf
@@ -6,6 +6,10 @@ data "google_iam_role" "workload_identity_pool_viewer" {
   name = "roles/iam.workloadIdentityPoolViewer"
 }
 
+data "google_iam_role" "cloudasset_viewer" {
+  name = "roles/cloudasset.viewer"
+}
+
 resource "google_project_iam_binding" "artifactregistry_administrator" {
   members = [
     "user:jonathan@pmqs.cloud"
@@ -20,4 +24,12 @@ resource "google_project_iam_binding" "workload_identity_pool_viewer" {
   ]
   project = google_project.primus_infrastructure.project_id
   role    = data.google_iam_role.workload_identity_pool_viewer.name
+}
+
+resource "google_project_iam_binding" "cloudasset_viewer" {
+  members = [
+    "user:jonathan@pmqs.cloud"
+  ]
+  project = google_project.primus_infrastructure.project_id
+  role    = data.google_iam_role.cloudasset_viewer.name
 }


### PR DESCRIPTION
As per title, there's a need to see more of the Workload Identity Pools in order to work out what's going on