### PR TITLE
Make sure we use the correct issuer URI

### DIFF
--- a/infrastructure/environments/gcp/primus_infrastructure/workload_identity.tf
+++ b/infrastructure/environments/gcp/primus_infrastructure/workload_identity.tf
@@ -14,7 +14,7 @@ resource "google_iam_workload_identity_pool_provider" "github_actions_pmqs_cloud
   display_name                       = "GitHub Actions (pmqs-cloud)"
   description                        = "Identity Pool Provider for publishing to Artifact Registry from GitHub Actions"
   oidc {
-    issuer_uri = "https://tokens.actions.githubusercontent.com"
+    issuer_uri = "https://token.actions.githubusercontent.com"
   }
   attribute_mapping = {
     "google.subject" : "assertion.sub"


### PR DESCRIPTION
As per title, we were using the `tokens` URI rather than `token` as its supposed to be, thus the errors we were seeing.