### PR TITLE
Add new GCS Bucket to store raw events

### DIFF
--- a/infrastructure/environments/gcp/primus_infrastructure/buckets.tf
+++ b/infrastructure/environments/gcp/primus_infrastructure/buckets.tf
@@ -1,0 +1,9 @@
+resource "google_storage_bucket" "raw_events" {
+  name          = "pmqs-raw-events"
+  location      = "US"
+  force_destroy = true
+
+  autoclass {
+    enabled = false
+  }
+}


### PR DESCRIPTION
As per title, take the first steps to adding a GCS Bucket that means we can start to store raw events