### PR TITLE
Consolidate IAM permissions in a single role

### DIFF
--- a/infrastructure/environments/gcp/primus_infrastructure/iam.tf
+++ b/infrastructure/environments/gcp/primus_infrastructure/iam.tf
@@ -1,35 +1,11 @@
-data "google_iam_role" "artifactregistry_administrator" {
-  name = "roles/artifactregistry.admin"
+data "google_iam_role" "security_reviewer" {
+  name = "roles/iam.securityReviewer"
 }
 
-data "google_iam_role" "workload_identity_pool_viewer" {
-  name = "roles/iam.workloadIdentityPoolViewer"
-}
-
-data "google_iam_role" "cloudasset_viewer" {
-  name = "roles/cloudasset.viewer"
-}
-
-resource "google_project_iam_binding" "artifactregistry_administrator" {
+resource "google_project_iam_binding" "security_reviewer" {
   members = [
     "user:jonathan@pmqs.cloud"
   ]
   project = google_project.primus_infrastructure.project_id
-  role    = data.google_iam_role.artifactregistry_administrator.name
-}
-
-resource "google_project_iam_binding" "workload_identity_pool_viewer" {
-  members = [
-    "user:jonathan@pmqs.cloud"
-  ]
-  project = google_project.primus_infrastructure.project_id
-  role    = data.google_iam_role.workload_identity_pool_viewer.name
-}
-
-resource "google_project_iam_binding" "cloudasset_viewer" {
-  members = [
-    "user:jonathan@pmqs.cloud"
-  ]
-  project = google_project.primus_infrastructure.project_id
-  role    = data.google_iam_role.cloudasset_viewer.name
+  role    = data.google_iam_role.security_reviewer.name
 }


### PR DESCRIPTION
As per title, it's very tedious to apply each role needed as we add each new GCP service, so instead let's use the broad ranging Security Reviewer permissions which should need to be updated less. We might move this up the organisational tree later on but for now it's fine to scope it to the single project