### PR TITLE
Deploying Pitt as a CloudRun Job

### DIFF
--- a/.github/workflows/build-primus-rust-services.yml
+++ b/.github/workflows/build-primus-rust-services.yml
@@ -122,12 +122,34 @@ jobs:
           fi
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Get Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        env:
+          DOCKER_METADATA_PR_HEAD_SHA: true
+        with:
+          images: ${{env.STONE_DOCKER_REPOSITORY}}/${{steps.read_name_from_cargo_toml.outputs.value}}
+          tags: |
+            type=semver,pattern={{version}},value=${{ steps.calculate_version.outputs.version }}
+            type=semver,pattern={{version}},value=v${{ steps.calculate_version.outputs.version }}
+            type=raw,value=prod,enable={{is_default_branch}}
+          labels: |
+            org.opencontainers.image.title=${{steps.read_name_from_cargo_toml.outputs.value}}
+            org.opencontainers.image.vendor=PMQs Cloud
+            org.opencontainers.image.licenses=Apache 2.0
+          annotations: |
+            org.opencontainers.image.title=${{ matrix.changed_dir }}
+            org.opencontainers.image.vendor=PMQs Cloud
+            org.opencontainers.image.licenses=Apache 2.0
       - name: Build and Push
         uses: docker/build-push-action@v6
         with:
           file: ${{ github.workspace }}/${{ matrix.rust_project }}/Dockerfile
           push: true
-          tags: ${{env.STONE_DOCKER_REPOSITORY}}/${{steps.read_name_from_cargo_toml.outputs.value}}:v${{steps.calculate_version.outputs.version}}, ${{env.STONE_DOCKER_REPOSITORY}}/${{steps.read_name_from_cargo_toml.outputs.value}}:${{steps.calculate_version.outputs.version}}
+          tags: ${{ steps.meta.outputs.tags }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          labels: ${{ steps.meta.outputs.labels }}
+
   check-builds-all-completes:
     name: Rust Docker Images Built & Pushed
     if: ${{ always() }}

--- a/deny.toml
+++ b/deny.toml
@@ -6,7 +6,8 @@ allow = [
     "LicenseRef-ring",
     "MIT",
     "MPL-2.0",
-    "Unicode-DFS-2016"
+    "Unicode-DFS-2016",
+    "Unicode-3.0"
 ]
 confidence-threshold = 0.8
 

--- a/infrastructure/environments/gcp/primus_infrastructure/buckets.tf
+++ b/infrastructure/environments/gcp/primus_infrastructure/buckets.tf
@@ -9,3 +9,15 @@ resource "google_storage_bucket" "raw_events" {
     enabled = false
   }
 }
+
+data "google_iam_role" "storage_object_creator" {
+  name = "roles/storage.objectCreator"
+}
+
+resource "google_storage_bucket_iam_binding" "pitt_access" {
+  bucket = google_storage_bucket.raw_events.name
+  members = [
+    google_service_account.cloud_run_pitt.member
+  ]
+  role = data.google_iam_role.storage_object_creator.name
+}

--- a/infrastructure/environments/gcp/primus_infrastructure/cloud_run_jobs.tf
+++ b/infrastructure/environments/gcp/primus_infrastructure/cloud_run_jobs.tf
@@ -59,7 +59,6 @@ resource "google_cloud_scheduler_job" "primus_scheduler" {
   }
 
   depends_on = [
-    google_project_service.enabled_apis["cloudscheduler.googleapis.com"],
-    google_cloud_run_v2_job.primus_jobs[each.key]
+    google_project_service.enabled_apis["cloudscheduler.googleapis.com"]
   ]
 }

--- a/infrastructure/environments/gcp/primus_infrastructure/cloud_run_jobs.tf
+++ b/infrastructure/environments/gcp/primus_infrastructure/cloud_run_jobs.tf
@@ -3,14 +3,20 @@ locals {
     pitt_weekly = {
       docker_image   = "us-central1-docker.pkg.dev/primus-infrastructure/stone/pitt:prod"
       cron_expresion = "0 14 * * 3"
-      args           = "--num-weeks 4"
-      description    = "A weekly job that looks back over the previous month to capture new PMQs instances"
+      args = [
+        "--num-weeks",
+        "4"
+      ]
+      description = "A weekly job that looks back over the previous month to capture new PMQs instances"
     },
     pitt_monthly = {
       docker_image   = "us-central1-docker.pkg.dev/primus-infrastructure/stone/pitt:prod"
       cron_expresion = "* 2 15 * *"
-      args           = "--start-date 01-11-1989"
-      description    = "A monthly job that looks back over all time (from when PMQs was first televised) to ensure we have everything"
+      args = [
+        "--start-date",
+        "01-11-1989"
+      ]
+      description = "A monthly job that looks back over all time (from when PMQs was first televised) to ensure we have everything"
     }
   }
 }
@@ -25,8 +31,8 @@ resource "google_cloud_run_v2_job" "primus_jobs" {
     template {
       containers {
         name  = "main"
-        image = value.docker_image
-        args  = value.args
+        image = each.value.docker_image
+        args  = each.value.args
       }
       service_account = google_service_account.cloud_run_pitt.email
     }

--- a/infrastructure/environments/gcp/primus_infrastructure/cloud_run_jobs.tf
+++ b/infrastructure/environments/gcp/primus_infrastructure/cloud_run_jobs.tf
@@ -1,0 +1,65 @@
+locals {
+  cloudrun_jobs = {
+    pitt_weekly = {
+      docker_image   = "us-central1-docker.pkg.dev/primus-infrastructure/stone/pitt:prod"
+      cron_expresion = "0 14 * * 3"
+      args           = "--num-weeks 4"
+      description    = "A weekly job that looks back over the previous month to capture new PMQs instances"
+    },
+    pitt_monthly = {
+      docker_image   = "us-central1-docker.pkg.dev/primus-infrastructure/stone/pitt:prod"
+      cron_expresion = "* 2 15 * *"
+      args           = "--start-date 01-11-1989"
+      description    = "A monthly job that looks back over all time (from when PMQs was first televised) to ensure we have everything"
+    }
+  }
+}
+
+resource "google_cloud_run_v2_job" "primus_jobs" {
+  for_each = local.cloudrun_jobs
+  name     = each.key
+  location = "us-central1"
+
+  template {
+    task_count = 1
+    template {
+      containers {
+        name  = "main"
+        image = value.docker_image
+        args  = value.args
+      }
+      service_account = google_service_account.cloud_run_pitt.email
+    }
+  }
+
+  depends_on = [
+    google_project_service.enabled_apis["run.googleapis.com"]
+  ]
+}
+
+resource "google_cloud_scheduler_job" "primus_scheduler" {
+  for_each    = local.cloudrun_jobs
+  name        = each.key
+  region      = "us-central1"
+  description = each.value.description
+  schedule    = each.value.cron_expresion
+  time_zone   = "Europe/London"
+
+  retry_config {
+    retry_count = 1
+  }
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://${google_cloud_run_v2_job.primus_jobs[each.key].location}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${google_project.primus_infrastructure.number}/jobs/${google_cloud_run_v2_job.primus_jobs[each.key].name}:run"
+
+    oauth_token {
+      service_account_email = google_service_account.cloud_run_pitt.email
+    }
+  }
+
+  depends_on = [
+    google_project_service.enabled_apis["cloudscheduler.googleapis.com"],
+    google_cloud_run_v2_job.primus_jobs[each.key]
+  ]
+}

--- a/infrastructure/environments/gcp/primus_infrastructure/project.tf
+++ b/infrastructure/environments/gcp/primus_infrastructure/project.tf
@@ -12,7 +12,9 @@ data "google_client_config" "this" {}
 locals {
   enabled_apis = [
     "artifactregistry.googleapis.com",
-    "iam.googleapis.com"
+    "iam.googleapis.com",
+    "run.googleapis.com",
+    "cloudscheduler.googleapis.com"
   ]
 }
 

--- a/infrastructure/environments/gcp/primus_infrastructure/service_accounts.tf
+++ b/infrastructure/environments/gcp/primus_infrastructure/service_accounts.tf
@@ -4,3 +4,10 @@ resource "google_service_account" "github_actions_pmqs_cloud" {
   description  = "The account through which GitHub Actions can publish artifacts"
   project      = google_project.primus_infrastructure.project_id
 }
+
+resource "google_service_account" "cloud_run_pitt" {
+  account_id   = "cloud-run-pitt"
+  display_name = "Cloud Run (pitt)"
+  description  = "A service account which provides access to GCS buckets for the pitt service"
+  project      = google_project.primus_infrastructure.project_id
+}

--- a/primus/pitt/Cargo.toml
+++ b/primus/pitt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pitt"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/primus/pitt/Cargo.toml
+++ b/primus/pitt/Cargo.toml
@@ -5,12 +5,14 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-clap = { version = "4.5.13", features = ["derive"] }
-reqwest = { version = "0.12.5", features = ["rustls-tls"], default-features = false }
-time = { version = "0.3.36", features = ["formatting", "parsing"] }
+clap = { version = "4.5.21", features = ["derive"] }
+google-cloud-storage = "0.22.1"
+reqwest = { version = "0.12.9", features = ["rustls-tls"], default-features = false }
+serde_json = "1.0.133"
 sxd-xpath = "0.4.2"
 sxd-document = "0.3.2"
-thiserror = "1.0.63"
-tracing = { workspace = true, features = ["log"] }
+thiserror = "2.0.3"
+time = { version = "0.3.36", features = ["formatting", "parsing"] }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
+tracing = { workspace = true, features = ["log"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "time"] }

--- a/primus/pitt/Dockerfile
+++ b/primus/pitt/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.80 AS build
+FROM rust:1.82 AS build
 
 # create a new empty shell project
 RUN mkdir /build

--- a/primus/pitt/src/errors.rs
+++ b/primus/pitt/src/errors.rs
@@ -1,3 +1,4 @@
+use google_cloud_storage::client::google_cloud_auth;
 use thiserror::Error;
 use tracing_subscriber::filter::FromEnvError;
 
@@ -7,10 +8,14 @@ pub enum PittError {
     EnvironmentVariableIncorrectDirectives(#[from] FromEnvError),
     #[error("Could not scan occurrences correctly")]
     ScanningError(#[from] ScanningError),
+    #[error("Could not create config correctly")]
+    ConfigError(#[from] google_cloud_auth::error::Error),
 }
 
 #[derive(Error, Debug)]
 pub enum ScanningError {
     #[error("Could not parse date correctly")]
     UnparsableDate(#[from] time::error::Format),
+    #[error("Could not upload data to GCS")]
+    UploadFailed(#[from] google_cloud_storage::http::Error),
 }

--- a/primus/pitt/src/main.rs
+++ b/primus/pitt/src/main.rs
@@ -3,6 +3,7 @@ mod scanner;
 
 use crate::errors::PittError;
 use clap::{arg, Args, Parser};
+use google_cloud_storage::client::{Client, ClientConfig};
 use time::{format_description, Duration, OffsetDateTime};
 use tracing::info;
 use tracing::level_filters::LevelFilter;
@@ -50,7 +51,12 @@ async fn main() -> Result<(), PittError> {
         earliest_date.date()
     );
 
-    scanner::run_scan(earliest_date, args.dry_run)
+    info!("Constructing GCS Client Config");
+    let config = ClientConfig::default().with_auth().await?;
+    info!("Constructing GCS Client");
+    let gcs_client = Client::new(config);
+
+    scanner::run_scan(earliest_date, args.dry_run, &gcs_client)
         .await
         .map_err(|e| e.into())
 }


### PR DESCRIPTION
Now that we've solidified the needs of our architecture we can deploy Pitt as a standalone Cloud Run job that simply dumps JSON files into a pre-defined GCS Bucket. This unfortunately requires some playing around with our CI process in order to add the right tags etc. but overall leads to this being deployed in a very agreeable and easy way.