### PR TITLE
Move around Terraform, and add GCS Viewer

### DIFF
--- a/infrastructure/environments/gcp/primus_infrastructure/buckets.tf
+++ b/infrastructure/environments/gcp/primus_infrastructure/buckets.tf
@@ -21,3 +21,15 @@ resource "google_storage_bucket_iam_binding" "pitt_access" {
   ]
   role = data.google_iam_role.storage_object_creator.name
 }
+
+data "google_iam_role" "storage_object_viewer" {
+  name = "roles/storage.objectViewer"
+}
+
+resource "google_storage_bucket_iam_binding" "personal_access" {
+  bucket = google_storage_bucket.raw_events.name
+  members = [
+    "user:jonathan@pmqs.cloud"
+  ]
+  role = data.google_iam_role.storage_object_viewer.name
+}

--- a/infrastructure/environments/gcp/primus_infrastructure/docker_repository.tf
+++ b/infrastructure/environments/gcp/primus_infrastructure/docker_repository.tf
@@ -2,6 +2,10 @@ data "google_iam_role" "artifact_registry_writer" {
   name = "roles/artifactregistry.writer"
 }
 
+data "google_iam_role" "artifactregistry_administrator" {
+  name = "roles/artifactregistry.admin"
+}
+
 resource "google_artifact_registry_repository" "stone" {
   location      = "us-central1"
   repository_id = "stone"
@@ -19,4 +23,12 @@ resource "google_project_iam_binding" "artifact_registry_writer" {
   ]
   project = google_project.primus_infrastructure.project_id
   role    = data.google_iam_role.artifact_registry_writer.name
+}
+
+resource "google_project_iam_binding" "artifactregistry_administrator" {
+  members = [
+    "user:jonathan@pmqs.cloud"
+  ]
+  project = google_project.primus_infrastructure.project_id
+  role    = data.google_iam_role.artifactregistry_administrator.name
 }

--- a/infrastructure/environments/gcp/primus_infrastructure/iam.tf
+++ b/infrastructure/environments/gcp/primus_infrastructure/iam.tf
@@ -2,9 +2,6 @@ data "google_iam_role" "security_reviewer" {
   name = "roles/iam.securityReviewer"
 }
 
-data "google_iam_role" "artifactregistry_administrator" {
-  name = "roles/artifactregistry.admin"
-}
 
 data "google_iam_role" "cloudrun_developer" {
   name = "roles/run.developer"
@@ -16,14 +13,6 @@ resource "google_project_iam_binding" "security_reviewer" {
   ]
   project = google_project.primus_infrastructure.project_id
   role    = data.google_iam_role.security_reviewer.name
-}
-
-resource "google_project_iam_binding" "artifactregistry_administrator" {
-  members = [
-    "user:jonathan@pmqs.cloud"
-  ]
-  project = google_project.primus_infrastructure.project_id
-  role    = data.google_iam_role.artifactregistry_administrator.name
 }
 
 resource "google_project_iam_binding" "cloudrun_developer" {


### PR DESCRIPTION
As per title, tried to move around the Terraform such that bindings are near resources in the case that they directly refer to those resources.

Further add the ability to download objects from GCS buckets to make debugging easier.