### PR TITLE
Fix date formats and output file names

### DIFF
--- a/infrastructure/environments/gcp/primus_infrastructure/cloud_run_jobs.tf
+++ b/infrastructure/environments/gcp/primus_infrastructure/cloud_run_jobs.tf
@@ -18,7 +18,7 @@ locals {
       cron_expresion = "* 2 15 * *"
       args = [
         "--start-date",
-        "01-11-1989"
+        "1989-11-01"
       ]
       description = "A monthly job that looks back over all time (from when PMQs was first televised) to ensure we have everything"
     }

--- a/primus/pitt/Cargo.toml
+++ b/primus/pitt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pitt"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/primus/pitt/src/scanner.rs
+++ b/primus/pitt/src/scanner.rs
@@ -41,7 +41,7 @@ pub(crate) async fn run_scan(
                                 "{}/{}-{}-{}.json",
                                 scan_timestamp,
                                 date.day(),
-                                date.month(),
+                                date.month() as u8,
                                 date.year()
                             );
                             info!(
@@ -53,7 +53,7 @@ pub(crate) async fn run_scan(
                                 gcs_client,
                                 key,
                                 json!({
-                                    "date": date.date(),
+                                    "date": date.format(&format)?,
                                     "xml_link": url
                                 }),
                             )


### PR DESCRIPTION
As per title, fix up how output names are rendered and further how dates are stored throughout the system. This data will have to be transferred between languages eventually so better to get it into an interoperable format now rather than later.